### PR TITLE
feat: Adds getSRGBLuminanceFromHex function

### DIFF
--- a/.changeset/angry-dolphins-tap.md
+++ b/.changeset/angry-dolphins-tap.md
@@ -1,0 +1,5 @@
+---
+"@sardine/colour": minor
+---
+
+feat: Add getSRGBLuminanceFromHex

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -1,5 +1,6 @@
 import type { LabColour, RGBColour, XYZColour } from "./types";
 import { constrainLab, linearRGB } from "./util/index.js";
+import { hexAlphaRegex, hexRegex, shortAlphaHexRegex, shortHexRegex } from "./util/regexers.js";
 
 /**
  * Converts sRGB colour space to XYZ.
@@ -60,15 +61,6 @@ export function convertRGBtoLab(colour: RGBColour): LabColour {
 }
 
 export function convertHextoRGB(hex: string): RGBColour {
-  /** Six digit Hexadecimal colour, ie: #12FF21 */
-  const hexRegex = /^#[a-fA-F0-9]{6}$/;
-  /** Eight digit Hexadecimal colour, ie: #12FF21BE */
-  const hexAlphaRegex = /^#[a-fA-F0-9]{8}$/;
-  /** Three digit Hexadecimal colour, ie: #FFF */
-  const shortHexRegex = /^#[a-fA-F0-9]{3}$/;
-  /** Four digit Hexadecimal colour, ie: #FFF4 */
-  const shortAlphaHexRegex = /^#[a-fA-F0-9]{4}$/;
-
   if (typeof hex !== "string") {
     throw new Error(`convertHextoRGB expects a string but got a ${typeof hex}`);
   }

--- a/src/getLuminance.ts
+++ b/src/getLuminance.ts
@@ -1,0 +1,22 @@
+import { convertHextoRGB } from "./converters.js";
+import { linearRGB } from "./util/index.js";
+
+/**
+ * Returns the relative luminance of a colour in the sRGB space.
+ *
+ * The calculations are compatible with WCAG3.0 as align with the sRGB spec
+ * and difference is minimal in a 8 bit channel.
+ *
+ * https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
+ *
+ * https://www.w3.org/WAI/GL/wiki/Relative_luminance
+ * @param colour an hexadecimal colour
+ */
+export const getLuminance = (colour: string) => {
+  const rgbColor = convertHextoRGB(colour);
+  const r = linearRGB(rgbColor.R);
+  const g = linearRGB(rgbColor.G);
+  const b = linearRGB(rgbColor.B);
+
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};

--- a/src/getSRGBLuminanceFromHex.ts
+++ b/src/getSRGBLuminanceFromHex.ts
@@ -4,15 +4,15 @@ import { linearRGB } from "./util/index.js";
 /**
  * Returns the relative luminance of a colour in the sRGB space.
  *
- * The calculations are compatible with WCAG3.0 as align with the sRGB spec
- * and difference is minimal in a 8 bit channel.
+ * The calculations are compatible with WCAG 3.0 as it aligns with the sRGB spec
+ * and difference to WCAG 2.1 is minimal in a 8 bit channel.
  *
  * https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
  *
  * https://www.w3.org/WAI/GL/wiki/Relative_luminance
  * @param colour an hexadecimal colour
  */
-export const getLuminance = (colour: string) => {
+export const getSRGBLuminanceFromHex = (colour: string) => {
   const rgbColor = convertHextoRGB(colour);
   const r = linearRGB(rgbColor.R);
   const g = linearRGB(rgbColor.G);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export {
   convertXYZtoLab,
 } from "./converters.js";
 export { RGBdistance } from "./RGBdistance.js";
+export { getSRGBLuminanceFromHex } from "./getSRGBLuminanceFromHex.js";

--- a/src/tests/getLuminance.test.ts
+++ b/src/tests/getLuminance.test.ts
@@ -1,0 +1,14 @@
+import test from "ava";
+import { getLuminance } from "../getLuminance.js";
+
+test("should return the luminance of a hex color", ({ is }) => {
+  is(getLuminance("#444"), 0.05780543019106723);
+});
+
+test("should return the luminance of an 8-digit hex color", ({ is }) => {
+  is(getLuminance("#6564CDB3"), 0.16288822420427432);
+});
+
+test("should return the luminance of an 4-digit hex color", ({ is }) => {
+  is(getLuminance("#0f08"), 0.7152);
+});

--- a/src/tests/getLuminance.test.ts
+++ b/src/tests/getLuminance.test.ts
@@ -1,14 +1,14 @@
 import test from "ava";
-import { getLuminance } from "../getLuminance.js";
+import { getSRGBLuminanceFromHex } from "../getSRGBLuminanceFromHex.js";
 
 test("should return the luminance of a hex color", ({ is }) => {
-  is(getLuminance("#444"), 0.05780543019106723);
+  is(getSRGBLuminanceFromHex("#444"), 0.05780543019106723);
 });
 
 test("should return the luminance of an 8-digit hex color", ({ is }) => {
-  is(getLuminance("#6564CDB3"), 0.16288822420427432);
+  is(getSRGBLuminanceFromHex("#6564CDB3"), 0.16288822420427432);
 });
 
 test("should return the luminance of an 4-digit hex color", ({ is }) => {
-  is(getLuminance("#0f08"), 0.7152);
+  is(getSRGBLuminanceFromHex("#0f08"), 0.7152);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,48 +1,50 @@
 /**
  * The RGB colour model represents a broad array of colours by describing the Red, Green and Blue channels.
  */
- export interface RGBColour {
-    /** A number between 0 and 255 to describe the Red colour channel */
-    R: number;
-    /** A number between 0 and 255 to describe the Green colour channel */
-    G: number;
-    /** A number between 0 and 255 to describe the Blue colour channel */
-    B: number;
-    /** A optional number between 0 and 1 to describe the Alpha colour channel */
-    A?: number;
-  }
-  
-  /**
-   * L*a*b* space is three-dimensional and covers the entire range of human colour perception
-   */
-  export interface LabColour {
-    /** A number between 0 and 100 to describe the colour's lightness. (0 - black, 100 - white)  */
-    L: number;
-    /** A number between -128 and 127 to describe the green–red opponent colors, with negative values toward green and positive values toward red */
-    a: number;
-    /** A number between -128 and 127 to describe  blue–yellow opponents, with negative numbers toward blue and positive toward yellow */
-    b: number;
-  }
-  
-  /**
-   * The CIE XYZ colour space is a device independent colour representation
-   */
-  export interface XYZColour {
-    /** X is a mix of response curves chosen to be nonnegative */
-    X: number;
-    /** Y as luminance */
-    Y: number;
-    /** Z is quasi-equal to blue */
-    Z: number;
-  }
+export interface RGBColour {
+  /** A number between 0 and 255 to describe the Red colour channel */
+  R: number;
+  /** A number between 0 and 255 to describe the Green colour channel */
+  G: number;
+  /** A number between 0 and 255 to describe the Blue colour channel */
+  B: number;
+  /** A optional number between 0 and 1 to describe the Alpha colour channel */
+  A?: number;
+}
 
-  export interface HueHelper {
-    /** Chroma for colour 1 */
-    C1: number;
-    /** Chroma for colour 2 */
-    C2: number;
-    /** Derivative of colour 1 Hue */
-    h1_d: number;
-    /** Derivative of colour 2 Hue */
-    h2_d: number;
-  }
+/**
+ * L*a*b* space is three-dimensional and covers the entire range of human colour perception
+ */
+export interface LabColour {
+  /** A number between 0 and 100 to describe the colour's lightness. (0 - black, 100 - white)  */
+  L: number;
+  /** A number between -128 and 127 to describe the green–red opponent colors, with negative values toward green and positive values toward red */
+  a: number;
+  /** A number between -128 and 127 to describe  blue–yellow opponents, with negative numbers toward blue and positive toward yellow */
+  b: number;
+}
+
+/**
+ * The CIE XYZ colour space is a device independent colour representation
+ */
+export interface XYZColour {
+  /** X is a mix of response curves chosen to be nonnegative */
+  X: number;
+  /** Y as luminance */
+  Y: number;
+  /** Z is quasi-equal to blue */
+  Z: number;
+}
+
+export interface HueHelper {
+  /** Chroma for colour 1 */
+  C1: number;
+  /** Chroma for colour 2 */
+  C2: number;
+  /** Derivative of colour 1 Hue */
+  h1_d: number;
+  /** Derivative of colour 2 Hue */
+  h2_d: number;
+}
+
+export type ColourSpace = "sRGB";

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -76,7 +76,7 @@ export const bigSquare = (n: number): number =>
 /**
  * Normalise black and white colorimetry as specified in IEC 61966-2-1
  * It takes a RGB channel in the range [0 - 255] and returns a value between 0 and 1
- * @param n number to be normalised
+ * @param rgbValue number to be normalised
  */
 export function linearRGB(rgbValue: number) {
   const rgbRatio = rgbValue / 255;

--- a/src/util/regexers.ts
+++ b/src/util/regexers.ts
@@ -1,0 +1,8 @@
+/** Six digit Hexadecimal colour, ie: #12FF21 */
+export const hexRegex = /^#[a-fA-F0-9]{6}$/;
+/** Eight digit Hexadecimal colour, ie: #12FF21BE */
+export const hexAlphaRegex = /^#[a-fA-F0-9]{8}$/;
+/** Three digit Hexadecimal colour, ie: #FFF */
+export const shortHexRegex = /^#[a-fA-F0-9]{3}$/;
+/** Four digit Hexadecimal colour, ie: #FFF4 */
+export const shortAlphaHexRegex = /^#[a-fA-F0-9]{4}$/;


### PR DESCRIPTION
`getSRGBLuminanceFromHex` returns the luminance value of a given colour in a 0 to 1 range.
It takes a colour in the hexadecimal format and the sRGB colour space.