### PR TITLE
feat/GH-103 Add getContrastRatioFromHex function

### DIFF
--- a/.changeset/shy-books-learn.md
+++ b/.changeset/shy-books-learn.md
@@ -1,0 +1,5 @@
+---
+"@sardine/colour": minor
+---
+
+Adds getContrastRatioFromHex

--- a/src/getContrastRatioFromHex.test.ts
+++ b/src/getContrastRatioFromHex.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { getContrastRatioFromHex } from "./getContrastRatioFromHex";
+import type { WCAG } from "./types";
+
+describe("getContrastRatioFromHex", () => {
+	const standard: WCAG = "WCAG2.1"; // Assuming WCAG2AA is a valid value for WCAG type
+
+	it("should return the correct contrast ratio for black and white", () => {
+		const ratio = getContrastRatioFromHex("#000000", "#FFFFFF", standard);
+		expect(ratio).toBe(21);
+	});
+
+	it("should return the correct contrast ratio for same colors", () => {
+		const ratio = getContrastRatioFromHex("#FFFFFF", "#FFFFFF", standard);
+		expect(ratio).toBe(1);
+	});
+
+	it("should return the correct contrast ratio for different colors", () => {
+		const ratio = getContrastRatioFromHex("#FF0000", "#00FF00", standard);
+		expect(ratio).toBe(2.913);
+	});
+
+	it("should return the correct contrast ratio within centesimal point", () => {
+		const ratio = getContrastRatioFromHex("#123456", "#123457", standard);
+		expect(ratio).toBe(1.001);
+	});
+
+	it("should pass the test for the classic rounding issue", () => {
+		const ratio = getContrastRatioFromHex("#777777", "#FFFFFF", standard);
+		expect(ratio).toBe(4.478);
+	});
+
+	it("should return the correct contrast ratio for light and dark grey", () => {
+		const ratio = getContrastRatioFromHex("#AAAAAA", "#555555", standard);
+		expect(ratio).toBe(3.209);
+	});
+});

--- a/src/getContrastRatioFromHex.ts
+++ b/src/getContrastRatioFromHex.ts
@@ -1,0 +1,31 @@
+import { getSRGBLuminanceFromHex } from "./getSRGBLuminanceFromHex";
+import type { WCAG } from "./types";
+
+/**
+ * Calculates the contrast ratio between two colours in hexadecimal format.
+ * @param colour1 The first colour in hexadecimal format
+ * @param colour2 The second colour in hexadecimal format
+ * @param standard The standard to evaluate the contrast ratio against, defaults to WCAG2.1
+ * @returns The contrast ratio between the two colours truncated to 3 decimal places
+ */
+export function getContrastRatioFromHex(
+	colour1: string,
+	colour2: string,
+	standard: WCAG,
+): number {
+	// Get the luminance of each colour
+	const luminance1 = getSRGBLuminanceFromHex(colour1, standard);
+	const luminance2 = getSRGBLuminanceFromHex(colour2, standard);
+
+	// Determine which colour is lighter and which is darker
+	const lighter = Math.max(luminance1, luminance2);
+	const darker = Math.min(luminance1, luminance2);
+
+	// Calculate the contrast ratio
+	// The spec sets the ratio as (L1 + 0.05) / (L2 + 0.05) where L1 is the lighter colour and L2 is the darker colour
+	// https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html
+	const ratio = (lighter + 0.05) / (darker + 0.05);
+
+	// Return the contrast ratio truncated to 3 decimal places
+	return Math.floor(ratio * 1000) / 1000;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export { findNearestColour } from "./findNearestColour";
 export { findNearestHexColour } from "./findNearestHexColour";
 export { findNearestNamedCSSColour } from "./findNearestNamedCSSColour";
 export { findNearestRGBColour } from "./findNearestRGBColour";
+export { getContrastRatioFromHex } from "./getContrastRatioFromHex";
 export { getSRGBLuminanceFromHex } from "./getSRGBLuminanceFromHex";
 export { getSRGBLuminanceFromRGB } from "./getSRGBLuminanceFromRGB";
 export { isCSSNamedDarkColour } from "./isCSSNameDarkColour";


### PR DESCRIPTION
Given two hexadecimal colours it calculates the contrast ration according to WCAG 2.1 rules